### PR TITLE
Add timeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,52 @@ schedule.on_calls(date)
 #=> ["someone@example.com", "someone-else@example.com"]
 ```
 
+You can also fetch a timeline for a schedule:
+
+```ruby
+schedule.timeline
+```
+
+Or a specific rotation:
+
+```ruby
+schedule.rotation[0].timeline
+```
+
+You can also specify where you want a timeline to start from:
+
+```ruby
+schedule.timeline(date: Date.parse("2019-01-01"))
+#=> [
+#     {
+#       "id"=>"69e7d46d-538e-4fca-95d0-5c316a54424e",
+#       "name"=>"On Call Phone",
+#       "order"=>2.0,
+#       "periods"=> [...]
+#     },
+#     ...
+#  ]
+```
+
+As well as the interval you want to see a timeline for:
+
+```ruby
+# `interval_unit` can be one of `:days`, `:weeks` or `:months`
+schedule.timeline(interval: 1, interval_unit: :months)
+#=> [...]
+```
+
+These options also work for a rotation's timeline too:
+
+```ruby
+schedule.rotation[0].timeline(
+  date: Date.parse("2019-01-01"),
+  interval: 1,
+  interval_unit: :months
+)
+#=> {...}
+```
+
 ## Development
 
 After checking out the repo, run `bundle install` to install dependencies. Then, run `rake spec` to run the tests.

--- a/lib/opsgenie/rotation.rb
+++ b/lib/opsgenie/rotation.rb
@@ -38,6 +38,16 @@ module Opsgenie
       on_calls.select { |name| participant_usernames.include?(name) }
     end
 
+    def timeline(date: Date.today, interval: nil, interval_unit: nil)
+      rotations = schedule.timeline(
+        date: date,
+        interval: interval,
+        interval_unit: interval_unit
+      )
+
+      rotations.find { |r| r["name"] == name }
+    end
+
     private
 
     def participant_usernames

--- a/lib/opsgenie/schedule.rb
+++ b/lib/opsgenie/schedule.rb
@@ -38,6 +38,8 @@ module Opsgenie
     end
 
     def timeline(date: Date.today, interval: nil, interval_unit: nil)
+      check_interval_unit(interval_unit) if interval_unit
+
       datetime = date.to_datetime
       endpoint = "schedules/#{id}/timeline?date=#{escape_datetime(datetime)}"
       endpoint += "&interval=#{interval}" if interval
@@ -56,6 +58,16 @@ module Opsgenie
 
     def escape_datetime(datetime)
       CGI.escape(datetime.to_s)
+    end
+
+    def check_interval_unit(value)
+      return if valid_intervals.include?(value)
+
+      raise ArgumentError, "`interval_unit` must be one of `#{valid_intervals}``"
+    end
+
+    def valid_intervals
+      %i[days weeks months]
     end
   end
 end

--- a/lib/opsgenie/schedule.rb
+++ b/lib/opsgenie/schedule.rb
@@ -32,9 +32,18 @@ module Opsgenie
 
     def on_calls(datetime = nil)
       endpoint = "schedules/#{id}/on-calls"
-      endpoint += "?date=#{CGI.escape datetime.to_s}" unless datetime.nil?
+      endpoint += "?date=#{escape_datetime(datetime)}" unless datetime.nil?
       body = Opsgenie::Client.get(endpoint)
       get_participants(body).map { |u| u["name"] }
+    end
+
+    def timeline(date: Date.today, interval: nil, interval_unit: nil)
+      datetime = date.to_datetime
+      endpoint = "schedules/#{id}/timeline?date=#{escape_datetime(datetime)}"
+      endpoint += "&interval=#{interval}" if interval
+      endpoint += "&intervalUnit=#{interval_unit}" if interval_unit
+      body = Opsgenie::Client.get(endpoint)
+      body.dig("data", "finalTimeline", "rotations")
     end
 
     private
@@ -43,6 +52,10 @@ module Opsgenie
       body["data"]["onCallParticipants"].select do |p|
         p["type"] == "user"
       end
+    end
+
+    def escape_datetime(datetime)
+      CGI.escape(datetime.to_s)
     end
   end
 end

--- a/spec/opsgenie/rotation_spec.rb
+++ b/spec/opsgenie/rotation_spec.rb
@@ -133,4 +133,79 @@ RSpec.describe Opsgenie::Rotation do
       end
     end
   end
+
+  describe "timeline" do
+    let(:body) do
+      {
+        data: {
+          finalTimeline: {
+            rotations: [
+              {
+                id: "538465d7-67d0-4d3d-80e0-e2a07a2b5649",
+                name: "OOH",
+                order: 5.0,
+                periods: [
+                  {
+                    startDate: "2019-11-06T18:00:00Z",
+                    endDate: "2019-11-07T10:00:00Z",
+                    type: "historical",
+                    recipient: {
+                      id: "8e3d055d-2b50-444d-ab89-d4353e831219",
+                      type: "user",
+                      name: "foo@example.com",
+                    },
+                    flattenedRecipients: [
+                      {
+                        id: "8e3d055d-2b50-444d-ab89-d4353e831219",
+                        type: "user",
+                        name: "foo@example.com",
+                      },
+                    ],
+                  },
+                ],
+              },
+              {
+                id: "12339",
+                name: "Dev",
+                order: 5.0,
+                periods: [
+                  {
+                    startDate: "2019-11-06T18:00:00Z",
+                    endDate: "2019-11-07T10:00:00Z",
+                    type: "historical",
+                    recipient: {
+                      id: "8e3d055d-2b50-444d-ab89-d4353e831219",
+                      type: "user",
+                      name: "foo@example.com",
+                    },
+                    flattenedRecipients: [
+                      {
+                        id: "8e3d055d-2b50-444d-ab89-d4353e831219",
+                        type: "user",
+                        name: "foo@example.com",
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        },
+      }
+    end
+    let(:datetime) { CGI.escape(Date.today.to_datetime.to_s) }
+    let(:timeline) { rotation.timeline }
+
+    it "makes the correct API call" do
+      url = "https://api.opsgenie.com/v2/schedules/123/timeline?date=#{datetime}"
+
+      stub = stub_request(:get, url)
+        .to_return(status: 200,
+                   body: body.to_json,
+                   headers: {"Content-Type" => "application/json"})
+
+      expect(timeline["id"]).to eq("12339")
+      expect(stub).to have_been_requested
+    end
+  end
 end

--- a/spec/opsgenie/schedule_spec.rb
+++ b/spec/opsgenie/schedule_spec.rb
@@ -199,4 +199,75 @@ RSpec.describe Opsgenie::Schedule do
       end
     end
   end
+
+  describe "timeline" do
+    let(:id) { "e71d500f-896a-4b28-8b08-3bfe56e1ed76" }
+    let(:schedule) { described_class.new("id" => id, "name" => "first_line", "rotations" => []) }
+    let(:body) do
+      {
+        data: {
+          finalTimeline: {
+            rotations: [
+              id: "538465d7-67d0-4d3d-80e0-e2a07a2b5649",
+              name: "OOH",
+              order: 5.0,
+              periods: [
+                {
+                  startDate: "2019-11-06T18:00:00Z",
+                  endDate: "2019-11-07T10:00:00Z",
+                  type: "historical",
+                  recipient: {
+                    id: "8e3d055d-2b50-444d-ab89-d4353e831219",
+                    type: "user",
+                    name: "foo@example.com",
+                  },
+                  flattenedRecipients: [
+                    {
+                      id: "8e3d055d-2b50-444d-ab89-d4353e831219",
+                      type: "user",
+                      name: "foo@example.com",
+                    },
+                  ],
+                },
+              ],
+            ],
+          },
+        },
+      }
+    end
+    let(:datetime) { CGI.escape(Date.today.to_datetime.to_s) }
+
+    context "with the default arguments" do
+      let(:url) { "https://api.opsgenie.com/v2/schedules/#{id}/timeline?date=#{datetime}" }
+      let(:timeline) { schedule.timeline }
+
+      it "returns data for the timeline" do
+        expect(timeline.count).to eq(1)
+        expect(timeline.first["id"]).to eq("538465d7-67d0-4d3d-80e0-e2a07a2b5649")
+        expect(stub).to have_been_requested
+      end
+    end
+
+    context "with date specified" do
+      let(:date) { Date.parse("2019-01-01") }
+      let(:datetime) { CGI.escape(date.to_datetime.to_s) }
+      let(:url) { "https://api.opsgenie.com/v2/schedules/#{id}/timeline?date=#{datetime}" }
+      let(:timeline) { schedule.timeline(date: date) }
+
+      it "adds the expected date to the url" do
+        expect(timeline.count).to eq(1)
+        expect(stub).to have_been_requested
+      end
+    end
+
+    context "with interval data specified" do
+      let(:url) { "https://api.opsgenie.com/v2/schedules/#{id}/timeline?date=#{datetime}&interval=1&intervalUnit=months" }
+      let(:timeline) { schedule.timeline(interval_unit: :months, interval: 1) }
+
+      it "adds the expected interval data to the url" do
+        expect(timeline.count).to eq(1)
+        expect(stub).to have_been_requested
+      end
+    end
+  end
 end

--- a/spec/opsgenie/schedule_spec.rb
+++ b/spec/opsgenie/schedule_spec.rb
@@ -269,5 +269,14 @@ RSpec.describe Opsgenie::Schedule do
         expect(stub).to have_been_requested
       end
     end
+
+    context "when interval unit is invalid" do
+      let(:url) { "https://api.opsgenie.com/v2/schedules/#{id}/timeline?date=#{datetime}&interval=1&intervalUnit=months" }
+      let(:timeline) { schedule.timeline(interval_unit: :eons, interval: 1) }
+
+      it "raises an error" do
+        expect { timeline }.to raise_error(ArgumentError)
+      end
+    end
   end
 end


### PR DESCRIPTION
This adds to the work done in the last PR to return an entire timeline for a schedule. By default, timelines are returned a month from the date of the request. More info:

https://docs.opsgenie.com/docs/schedule-api#section-get-schedule-timeline
