### PR TITLE
Get users from API

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,10 @@ You can then fetch the people scheduled for today like so:
 
 ```ruby
 schedule.on_calls
-#=> ["someone@example.com", "someone-else@example.com"]
+#=> [
+#     <Opsgenie::User @full_name="Someone", @id=1234, @username="someone@example.com">,
+#     <Opsgenie::User @full_name="Someone Else", @id=1236, @username="somesomeone-elseone@example.com">
+#]
 ```
 
 Or a given date time like so:
@@ -58,7 +61,10 @@ Or a given date time like so:
 ```ruby
 date = DateTime.parse("2019-01-01T10:00:00")
 schedule.on_calls(date)
-#=> ["someone@example.com", "someone-else@example.com"]
+#=> [
+#     <Opsgenie::User @full_name="Someone", @id=1234, @username="someone@example.com">,
+#     <Opsgenie::User @full_name="Someone Else", @id=1236, @username="somesomeone-elseone@example.com">
+#]
 ```
 
 You can also fetch a timeline for a schedule:

--- a/README.md
+++ b/README.md
@@ -83,15 +83,23 @@ You can also specify where you want a timeline to start from:
 
 ```ruby
 schedule.timeline(date: Date.parse("2019-01-01"))
-#=> [
-#     {
-#       "id"=>"69e7d46d-538e-4fca-95d0-5c316a54424e",
-#       "name"=>"On Call Phone",
-#       "order"=>2.0,
-#       "periods"=> [...]
-#     },
-#     ...
-#  ]
+# => [#<Opsgenie::TimelineRotation:0x00007f9b2f974cb8
+#   @id="69e7d46d-538e-4fca-95d0-5c316a54424e",
+#   @name="On Call Phone",
+#   @periods=
+#    [#<Opsgenie::TimelinePeriod:0x00007f9b2f974c40
+#      @end_date=#<DateTime: 2019-12-05T11:55:29+00:00 ((2458823j,42929s,816000000n),+0s,2299161j)>,
+#      @start_date=#<DateTime: 2019-12-02T00:00:00+00:00 ((2458820j,0s,0n),+0s,2299161j)>,
+#      @user=
+#       #<Opsgenie::User:0x00007f9b2f329520
+#        @full_name="On Call Phone",
+#        @id="19e39115-07d5-4924-8295-332a66dd1569",
+#        @username="systems@dxw.com">>,
+#     ...]
+#    ],
+#    ...
+#   ]
+#  >
 ```
 
 As well as the interval you want to see a timeline for:
@@ -110,7 +118,7 @@ schedule.rotation[0].timeline(
   interval: 1,
   interval_unit: :months
 )
-#=> {...}
+#=> <Opsgenie::TimelineRotation:0x00007f9b2f974cb8>
 ```
 
 ## Development

--- a/lib/opsgenie.rb
+++ b/lib/opsgenie.rb
@@ -5,6 +5,8 @@ require "opsgenie/schedule"
 require "opsgenie/rotation"
 require "opsgenie/user"
 require "opsgenie/config"
+require "opsgenie/timeline_rotation"
+require "opsgenie/timeline_period"
 
 module Opsgenie
   def self.configure(api_key:)

--- a/lib/opsgenie.rb
+++ b/lib/opsgenie.rb
@@ -3,6 +3,7 @@ require "httparty"
 require "opsgenie/client"
 require "opsgenie/schedule"
 require "opsgenie/rotation"
+require "opsgenie/user"
 require "opsgenie/config"
 
 module Opsgenie

--- a/lib/opsgenie/rotation.rb
+++ b/lib/opsgenie/rotation.rb
@@ -45,7 +45,7 @@ module Opsgenie
         interval_unit: interval_unit
       )
 
-      rotations.find { |r| r["name"] == name }
+      rotations.find { |r| r.name == name }
     end
 
     private

--- a/lib/opsgenie/rotation.rb
+++ b/lib/opsgenie/rotation.rb
@@ -35,7 +35,7 @@ module Opsgenie
       )
 
       on_calls = schedule.on_calls((time + 60).to_datetime)
-      on_calls.select { |name| participant_usernames.include?(name) }
+      on_calls.select { |user| participant_usernames.include?(user.username) }
     end
 
     def timeline(date: Date.today, interval: nil, interval_unit: nil)

--- a/lib/opsgenie/schedule.rb
+++ b/lib/opsgenie/schedule.rb
@@ -45,7 +45,9 @@ module Opsgenie
       endpoint += "&interval=#{interval}" if interval
       endpoint += "&intervalUnit=#{interval_unit}" if interval_unit
       body = Opsgenie::Client.get(endpoint)
-      body.dig("data", "finalTimeline", "rotations")
+      body.dig("data", "finalTimeline", "rotations").map do |rotation|
+        TimelineRotation.new(rotation)
+      end
     end
 
     private

--- a/lib/opsgenie/schedule.rb
+++ b/lib/opsgenie/schedule.rb
@@ -34,7 +34,7 @@ module Opsgenie
       endpoint = "schedules/#{id}/on-calls"
       endpoint += "?date=#{escape_datetime(datetime)}" unless datetime.nil?
       body = Opsgenie::Client.get(endpoint)
-      get_participants(body).map { |u| u["name"] }
+      get_participants(body).map { |u| User.find_by_username(u["name"]) }
     end
 
     def timeline(date: Date.today, interval: nil, interval_unit: nil)

--- a/lib/opsgenie/timeline_period.rb
+++ b/lib/opsgenie/timeline_period.rb
@@ -1,0 +1,10 @@
+module Opsgenie
+  class TimelinePeriod
+    attr_reader :start_date, :end_date, :user
+    def initialize(attrs)
+      @start_date = DateTime.parse(attrs["startDate"])
+      @end_date = DateTime.parse(attrs["endDate"])
+      @user = Opsgenie::User.find(attrs["recipient"]["id"])
+    end
+  end
+end

--- a/lib/opsgenie/timeline_rotation.rb
+++ b/lib/opsgenie/timeline_rotation.rb
@@ -1,0 +1,11 @@
+module Opsgenie
+  class TimelineRotation
+    attr_reader :id, :name, :periods
+
+    def initialize(attrs)
+      @id = attrs["id"]
+      @name = attrs["name"]
+      @periods = attrs["periods"].map { |p| TimelinePeriod.new(p) }
+    end
+  end
+end

--- a/lib/opsgenie/user.rb
+++ b/lib/opsgenie/user.rb
@@ -1,0 +1,20 @@
+require "date"
+
+module Opsgenie
+  class User
+    class << self
+      def all
+        body = Opsgenie::Client.get("users?limit=500")
+        body["data"].map { |s| new(s) }
+      end
+    end
+
+    attr_reader :id, :username, :full_name
+
+    def initialize(attrs)
+      @id = attrs["id"]
+      @username = attrs["username"]
+      @full_name = attrs["fullName"]
+    end
+  end
+end

--- a/lib/opsgenie/user.rb
+++ b/lib/opsgenie/user.rb
@@ -7,6 +7,21 @@ module Opsgenie
         body = Opsgenie::Client.get("users?limit=500")
         body["data"].map { |s| new(s) }
       end
+
+      def find_by_username(username)
+        find_by(:username, username)
+      end
+
+      def find(id)
+        find_by(:id, id)
+      end
+
+      private
+
+      def find_by(key, value)
+        @users ||= all
+        @users.find { |user| user.send(key) == value }
+      end
     end
 
     attr_reader :id, :username, :full_name

--- a/spec/fixtures/schedule.json
+++ b/spec/fixtures/schedule.json
@@ -1,0 +1,25 @@
+{
+  "data":{
+     "id":"b8e97704-0e9d-41b5-b27c-9d9027c83943",
+     "name":"ooh_second_line",
+     "description":"",
+     "timezone":"Europe/London",
+     "enabled":true,
+     "rotations":[
+        {
+           "id":"6fce1fd0-578a-431a-8c18-ae7db8b48bb5",
+           "name":"Rota",
+           "startDate":"2019-11-27T10:30:00Z",
+           "type":"weekly",
+           "length":1,
+           "participants":[
+              {
+                 "type":"user",
+                 "id":"055dad59-af7f-42a3-8591-9ac04863e546",
+                 "username":"foo@example.com"
+              }
+           ]
+        }
+     ]
+  }
+}

--- a/spec/fixtures/users.json
+++ b/spec/fixtures/users.json
@@ -1,0 +1,68 @@
+{
+  "totalCount":8,
+  "data":[
+     {
+        "blocked":false,
+        "verified":false,
+        "id":"b5b92115-bfe7-43eb-8c2a-e467f2e5ddc4",
+        "username":"john.doe@opsgenie.com",
+        "fullName":"john doe",
+        "role":{
+           "id":"Admin",
+           "name":"Admin"
+        },
+        "timeZone":"Europe/Kirov",
+        "locale":"en_US",
+        "userAddress":{
+           "country":"",
+           "state":"",
+           "city":"",
+           "line":"",
+           "zipCode":""
+        },
+        "createdAt":"2017-05-12T08:34:30.283Z"
+     },
+     {
+        "blocked":false,
+        "verified":false,
+        "id":"e07c63f0-dd8c-4ad4-983e-4ee7dc600463",
+        "username":"jane.doe@opsgenie.com",
+        "fullName":"jane doe",
+        "role":{
+           "id":"Admin",
+           "name":"Admin"
+        },
+        "timeZone":"Europe/Moscow",
+        "locale":"en_GB",
+        "tags":[
+           "tag1",
+           "tag3"
+        ],
+        "userAddress":{
+           "country":"US",
+           "state":"Indiana",
+           "city":"Terre Haute",
+           "line":"567 Stratford Park",
+           "zipCode":"47802"
+        },
+        "details":{
+           "detail1key":[
+              "detail1dvalue1",
+              "detail1value2"
+           ],
+           "detail2key":[
+              "detail2value"
+           ]
+        },
+        "createdAt":"2017-05-12T09:39:14.41Z"
+     }
+  ],
+  "paging":{
+     "prev":"http://api.opsgenie.com/v2/users?limit=2&offset=1&order=DESC&sort=fullName&query=role%3Aadmin",
+     "next":"http://api.opsgenie.com/v2/users?limit=2&offset=5&order=DESC&sort=fullName&query=role%3Aadmin",
+     "first":"http://api.opsgenie.com/v2/users?limit=2&offset=0&order=DESC&sort=fullName&query=role%3Aadmin",
+     "last":"http://api.opsgenie.com/v2/users?limit=2&offset=6&order=DESC&sort=fullName&query=role%3Aadmin"
+  },
+  "took":0.261,
+  "requestId":"d2c50d0c-1c44-4fa5-99d4-20d1e7ca9938"
+}

--- a/spec/opsgenie/rotation_spec.rb
+++ b/spec/opsgenie/rotation_spec.rb
@@ -182,11 +182,12 @@ RSpec.describe Opsgenie::Rotation do
     let(:timeline) { rotation.timeline }
 
     it "makes the correct API call" do
+      stub_user_list_request
       url = "https://api.opsgenie.com/v2/schedules/123/timeline?date=#{datetime}"
 
       stub = stub_get_request(url, body)
 
-      expect(timeline["id"]).to eq("12339")
+      expect(timeline.id).to eq("12339")
       expect(stub).to have_been_requested
     end
   end

--- a/spec/opsgenie/rotation_spec.rb
+++ b/spec/opsgenie/rotation_spec.rb
@@ -11,12 +11,7 @@ RSpec.describe Opsgenie::Rotation do
       "participants" => [
         {
           "id" => "19e39115-07d5-4924-8295-332a66dd1569",
-          "username" => "foo@example.com",
-          "type" => "user",
-        },
-        {
-          "id" => "acd9af98-e3c0-4588-8276-1c545911e44f",
-          "username" => "bar@example.com",
+          "username" => "john.doe@opsgenie.com",
           "type" => "user",
         },
       ],
@@ -90,17 +85,7 @@ RSpec.describe Opsgenie::Rotation do
             onCallParticipants: [
               {
                 id: "19e39115-07d5-4924-8295-332a66dd1569",
-                name: "foo@example.com",
-                type: "user",
-              },
-              {
-                id: "acd9af98-e3c0-4588-8276-1c545911e44f",
-                name: "bar@example.com",
-                type: "user",
-              },
-              {
-                id: "9de61103-0d61-4f86-9dbf-154bbdca9cd8",
-                name: "baz@example.com",
+                name: "john.doe@opsgenie.com",
                 type: "user",
               },
             ],
@@ -113,11 +98,14 @@ RSpec.describe Opsgenie::Rotation do
       let(:date) { Date.parse("2019-11-29") }
 
       it "makes the correct API call" do
+        stub_user_list_request
         url = "https://api.opsgenie.com/v2/schedules/123/on-calls?date=2019-11-29T10:01:00%2B00:00"
 
         stub = stub_get_request(url, body)
 
-        expect(on_calls).to eq(["foo@example.com", "bar@example.com"])
+        expect(on_calls.count).to eq(1)
+        expect(on_calls.first.username).to eq("john.doe@opsgenie.com")
+
         expect(stub).to have_been_requested
       end
     end

--- a/spec/opsgenie/rotation_spec.rb
+++ b/spec/opsgenie/rotation_spec.rb
@@ -115,10 +115,7 @@ RSpec.describe Opsgenie::Rotation do
       it "makes the correct API call" do
         url = "https://api.opsgenie.com/v2/schedules/123/on-calls?date=2019-11-29T10:01:00%2B00:00"
 
-        stub = stub_request(:get, url)
-          .to_return(status: 200,
-                     body: body.to_json,
-                     headers: {"Content-Type" => "application/json"})
+        stub = stub_get_request(url, body)
 
         expect(on_calls).to eq(["foo@example.com", "bar@example.com"])
         expect(stub).to have_been_requested
@@ -199,10 +196,7 @@ RSpec.describe Opsgenie::Rotation do
     it "makes the correct API call" do
       url = "https://api.opsgenie.com/v2/schedules/123/timeline?date=#{datetime}"
 
-      stub = stub_request(:get, url)
-        .to_return(status: 200,
-                   body: body.to_json,
-                   headers: {"Content-Type" => "application/json"})
+      stub = stub_get_request(url, body)
 
       expect(timeline["id"]).to eq("12339")
       expect(stub).to have_been_requested

--- a/spec/opsgenie/schedule_spec.rb
+++ b/spec/opsgenie/schedule_spec.rb
@@ -223,10 +223,11 @@ RSpec.describe Opsgenie::Schedule do
       let(:timeline) { schedule.timeline }
 
       it "returns data for the timeline" do
+        stub_user_list_request
         stub = stub_get_request(url, body)
 
         expect(timeline.count).to eq(1)
-        expect(timeline.first["id"]).to eq("538465d7-67d0-4d3d-80e0-e2a07a2b5649")
+        expect(timeline.first.id).to eq("538465d7-67d0-4d3d-80e0-e2a07a2b5649")
         expect(stub).to have_been_requested
       end
     end
@@ -250,6 +251,7 @@ RSpec.describe Opsgenie::Schedule do
       let(:timeline) { schedule.timeline(interval_unit: :months, interval: 1) }
 
       it "adds the expected interval data to the url" do
+        stub_user_list_request
         stub = stub_get_request(url, body)
 
         expect(timeline.count).to eq(1)

--- a/spec/opsgenie/schedule_spec.rb
+++ b/spec/opsgenie/schedule_spec.rb
@@ -128,17 +128,12 @@ RSpec.describe Opsgenie::Schedule do
           onCallParticipants: [
             {
               id: "19e39115-07d5-4924-8295-332a66dd1569",
-              name: "foo@example.com",
+              name: "john.doe@opsgenie.com",
               type: "user",
             },
             {
               id: "acd9af98-e3c0-4588-8276-1c545911e44f",
-              name: "bar@example.com",
-              type: "user",
-            },
-            {
-              id: "9de61103-0d61-4f86-9dbf-154bbdca9cd8",
-              name: "baz@example.com",
+              name: "jane.doe@opsgenie.com",
               type: "user",
             },
           ],
@@ -153,13 +148,15 @@ RSpec.describe Opsgenie::Schedule do
       let(:url) { "https://api.opsgenie.com/v2/schedules/#{id}/on-calls" }
 
       it "returns the expected users" do
+        stub_user_list_request
         stub = stub_get_request(url, body)
 
-        expect(on_calls).to eq([
-          "foo@example.com",
-          "bar@example.com",
-          "baz@example.com",
-        ])
+        expect(on_calls.count).to eq(2)
+        expect(on_calls[0]).to be_a(Opsgenie::User)
+        expect(on_calls[0].username).to eq("john.doe@opsgenie.com")
+        expect(on_calls[1]).to be_a(Opsgenie::User)
+        expect(on_calls[1].username).to eq("jane.doe@opsgenie.com")
+
         expect(stub).to have_been_requested
       end
     end
@@ -170,13 +167,15 @@ RSpec.describe Opsgenie::Schedule do
       let(:url) { "https://api.opsgenie.com/v2/schedules/#{id}/on-calls?date=2019-10-25T00:00:00%2B00:00" }
 
       it "returns the expected users" do
+        stub_user_list_request
         stub = stub_get_request(url, body)
 
-        expect(on_calls).to eq([
-          "foo@example.com",
-          "bar@example.com",
-          "baz@example.com",
-        ])
+        expect(on_calls.count).to eq(2)
+        expect(on_calls[0]).to be_a(Opsgenie::User)
+        expect(on_calls[0].username).to eq("john.doe@opsgenie.com")
+        expect(on_calls[1]).to be_a(Opsgenie::User)
+        expect(on_calls[1].username).to eq("jane.doe@opsgenie.com")
+
         expect(stub).to have_been_requested
       end
     end

--- a/spec/opsgenie/timeline_period_spec.rb
+++ b/spec/opsgenie/timeline_period_spec.rb
@@ -1,0 +1,18 @@
+require "spec_helper"
+
+RSpec.describe Opsgenie::TimelinePeriod do
+  it "marshals a hash into a the correct shape" do
+    stub_user_list_request
+    attrs = {
+      "startDate" => "2019-01-01T10:00:00Z",
+      "endDate" => "2019-01-01T18:00:00Z",
+      "recipient" => {
+        "id" => "b5b92115-bfe7-43eb-8c2a-e467f2e5ddc4",
+      },
+    }
+    period = Opsgenie::TimelinePeriod.new(attrs)
+    expect(period.start_date).to eq(DateTime.parse(attrs["startDate"]))
+    expect(period.end_date).to eq(DateTime.parse(attrs["endDate"]))
+    expect(period.user.username).to eq("john.doe@opsgenie.com")
+  end
+end

--- a/spec/opsgenie/user_spec.rb
+++ b/spec/opsgenie/user_spec.rb
@@ -1,77 +1,78 @@
 require "spec_helper"
 
 RSpec.describe Opsgenie::User do
-  describe "#all" do
-    let!(:stub) do
-      stub_request(:get, url)
-        .to_return(
-          body: body.to_json,
-          headers: {"Content-Type" => "application/json"}
-        )
-    end
-    let(:url) { "https://api.opsgenie.com/v2/users?limit=500" }
-    let(:body) do
-      {
-        totalCount: 8,
-        data: [
-          {
-            blocked: false,
-            verified: false,
-            id: "b5b92115-bfe7-43eb-8c2a-e467f2e5ddc4",
-            username: "john.doe@opsgenie.com",
-            fullName: "john doe",
-            role: {
-              id: "Admin",
-              name: "Admin",
-            },
-            timeZone: "Europe/Kirov",
-            locale: "en_US",
-            userAddress: {
-              country: "",
-              state: "",
-              city: "",
-              line: "",
-              zipCode: "",
-            },
-            createdAt: "2017-05-12T08:34:30.283Z",
+  let!(:stub) do
+    stub_request(:get, url)
+      .to_return(
+        body: body.to_json,
+        headers: {"Content-Type" => "application/json"}
+      )
+  end
+  let(:url) { "https://api.opsgenie.com/v2/users?limit=500" }
+  let(:body) do
+    {
+      totalCount: 8,
+      data: [
+        {
+          blocked: false,
+          verified: false,
+          id: "b5b92115-bfe7-43eb-8c2a-e467f2e5ddc4",
+          username: "john.doe@opsgenie.com",
+          fullName: "john doe",
+          role: {
+            id: "Admin",
+            name: "Admin",
           },
-          {
-            blocked: false,
-            verified: false,
-            id: "e07c63f0-dd8c-4ad4-983e-4ee7dc600463",
-            username: "jane.doe@opsgenie.com",
-            fullName: "jane doe",
-            role: {
-              id: "Admin",
-              name: "Admin",
-            },
-            timeZone: "Europe/Moscow",
-            locale: "en_GB",
-            tags: ["tag1", "tag3"],
-            userAddress: {
-              country: "US",
-              state: "Indiana",
-              city: "Terre Haute",
-              line: "567 Stratford Park",
-              zipCode: "47802",
-            },
-            details: {
-              detail1key: ["detail1dvalue1", "detail1value2"],
-              detail2key: ["detail2value"],
-            },
-            createdAt: "2017-05-12T09:39:14.41Z",
+          timeZone: "Europe/Kirov",
+          locale: "en_US",
+          userAddress: {
+            country: "",
+            state: "",
+            city: "",
+            line: "",
+            zipCode: "",
           },
-        ],
-        paging: {
-          prev: "http://api.opsgenie.com/v2/users?limit=2&offset=1&order=DESC&sort=fullName&query=role%3Aadmin",
-          next: "http://api.opsgenie.com/v2/users?limit=2&offset=5&order=DESC&sort=fullName&query=role%3Aadmin",
-          first: "http://api.opsgenie.com/v2/users?limit=2&offset=0&order=DESC&sort=fullName&query=role%3Aadmin",
-          last: "http://api.opsgenie.com/v2/users?limit=2&offset=6&order=DESC&sort=fullName&query=role%3Aadmin",
+          createdAt: "2017-05-12T08:34:30.283Z",
         },
-        took: 0.261,
-        requestId: "d2c50d0c-1c44-4fa5-99d4-20d1e7ca9938",
-      }
-    end
+        {
+          blocked: false,
+          verified: false,
+          id: "e07c63f0-dd8c-4ad4-983e-4ee7dc600463",
+          username: "jane.doe@opsgenie.com",
+          fullName: "jane doe",
+          role: {
+            id: "Admin",
+            name: "Admin",
+          },
+          timeZone: "Europe/Moscow",
+          locale: "en_GB",
+          tags: ["tag1", "tag3"],
+          userAddress: {
+            country: "US",
+            state: "Indiana",
+            city: "Terre Haute",
+            line: "567 Stratford Park",
+            zipCode: "47802",
+          },
+          details: {
+            detail1key: ["detail1dvalue1", "detail1value2"],
+            detail2key: ["detail2value"],
+          },
+          createdAt: "2017-05-12T09:39:14.41Z",
+        },
+      ],
+      paging: {
+        prev: "http://api.opsgenie.com/v2/users?limit=2&offset=1&order=DESC&sort=fullName&query=role%3Aadmin",
+        next: "http://api.opsgenie.com/v2/users?limit=2&offset=5&order=DESC&sort=fullName&query=role%3Aadmin",
+        first: "http://api.opsgenie.com/v2/users?limit=2&offset=0&order=DESC&sort=fullName&query=role%3Aadmin",
+        last: "http://api.opsgenie.com/v2/users?limit=2&offset=6&order=DESC&sort=fullName&query=role%3Aadmin",
+      },
+      took: 0.261,
+      requestId: "d2c50d0c-1c44-4fa5-99d4-20d1e7ca9938",
+    }
+  end
+
+  describe "#all" do
     let(:users) { described_class.all }
 
     it "returns all users" do
@@ -82,6 +83,48 @@ RSpec.describe Opsgenie::User do
       expect(users.first.full_name).to eq("john doe")
 
       expect(stub).to have_been_requested
+    end
+  end
+
+  describe "#find_by_username" do
+    let(:user) { described_class.find_by_username(username) }
+
+    context "when user exists" do
+      let(:username) { "jane.doe@opsgenie.com" }
+
+      it "returns a user" do
+        expect(user).to be_a(Opsgenie::User)
+        expect(user.username).to eq(username)
+      end
+    end
+
+    context "when user does not exist" do
+      let(:username) { "foo@opsgenie.com" }
+
+      it "returns nil" do
+        expect(user).to eq(nil)
+      end
+    end
+  end
+
+  describe "#find_by_id" do
+    let(:user) { described_class.find(id) }
+
+    context "when user exists" do
+      let(:id) { "e07c63f0-dd8c-4ad4-983e-4ee7dc600463" }
+
+      it "returns a user" do
+        expect(user).to be_a(Opsgenie::User)
+        expect(user.id).to eq(id)
+      end
+    end
+
+    context "when user does not exist" do
+      let(:id) { "f321323" }
+
+      it "returns nil" do
+        expect(user).to eq(nil)
+      end
     end
   end
 end

--- a/spec/opsgenie/user_spec.rb
+++ b/spec/opsgenie/user_spec.rb
@@ -1,0 +1,87 @@
+require "spec_helper"
+
+RSpec.describe Opsgenie::User do
+  describe "#all" do
+    let!(:stub) do
+      stub_request(:get, url)
+        .to_return(
+          body: body.to_json,
+          headers: {"Content-Type" => "application/json"}
+        )
+    end
+    let(:url) { "https://api.opsgenie.com/v2/users?limit=500" }
+    let(:body) do
+      {
+        totalCount: 8,
+        data: [
+          {
+            blocked: false,
+            verified: false,
+            id: "b5b92115-bfe7-43eb-8c2a-e467f2e5ddc4",
+            username: "john.doe@opsgenie.com",
+            fullName: "john doe",
+            role: {
+              id: "Admin",
+              name: "Admin",
+            },
+            timeZone: "Europe/Kirov",
+            locale: "en_US",
+            userAddress: {
+              country: "",
+              state: "",
+              city: "",
+              line: "",
+              zipCode: "",
+            },
+            createdAt: "2017-05-12T08:34:30.283Z",
+          },
+          {
+            blocked: false,
+            verified: false,
+            id: "e07c63f0-dd8c-4ad4-983e-4ee7dc600463",
+            username: "jane.doe@opsgenie.com",
+            fullName: "jane doe",
+            role: {
+              id: "Admin",
+              name: "Admin",
+            },
+            timeZone: "Europe/Moscow",
+            locale: "en_GB",
+            tags: ["tag1", "tag3"],
+            userAddress: {
+              country: "US",
+              state: "Indiana",
+              city: "Terre Haute",
+              line: "567 Stratford Park",
+              zipCode: "47802",
+            },
+            details: {
+              detail1key: ["detail1dvalue1", "detail1value2"],
+              detail2key: ["detail2value"],
+            },
+            createdAt: "2017-05-12T09:39:14.41Z",
+          },
+        ],
+        paging: {
+          prev: "http://api.opsgenie.com/v2/users?limit=2&offset=1&order=DESC&sort=fullName&query=role%3Aadmin",
+          next: "http://api.opsgenie.com/v2/users?limit=2&offset=5&order=DESC&sort=fullName&query=role%3Aadmin",
+          first: "http://api.opsgenie.com/v2/users?limit=2&offset=0&order=DESC&sort=fullName&query=role%3Aadmin",
+          last: "http://api.opsgenie.com/v2/users?limit=2&offset=6&order=DESC&sort=fullName&query=role%3Aadmin",
+        },
+        took: 0.261,
+        requestId: "d2c50d0c-1c44-4fa5-99d4-20d1e7ca9938",
+      }
+    end
+    let(:users) { described_class.all }
+
+    it "returns all users" do
+      expect(users.count).to eq(2)
+      expect(users.first).to be_a(Opsgenie::User)
+      expect(users.first.id).to eq("b5b92115-bfe7-43eb-8c2a-e467f2e5ddc4")
+      expect(users.first.username).to eq("john.doe@opsgenie.com")
+      expect(users.first.full_name).to eq("john doe")
+
+      expect(stub).to have_been_requested
+    end
+  end
+end

--- a/spec/opsgenie/user_spec.rb
+++ b/spec/opsgenie/user_spec.rb
@@ -1,81 +1,12 @@
 require "spec_helper"
 
 RSpec.describe Opsgenie::User do
-  let!(:stub) do
-    stub_request(:get, url)
-      .to_return(
-        body: body.to_json,
-        headers: {"Content-Type" => "application/json"}
-      )
-  end
-  let(:url) { "https://api.opsgenie.com/v2/users?limit=500" }
-  let(:body) do
-    {
-      totalCount: 8,
-      data: [
-        {
-          blocked: false,
-          verified: false,
-          id: "b5b92115-bfe7-43eb-8c2a-e467f2e5ddc4",
-          username: "john.doe@opsgenie.com",
-          fullName: "john doe",
-          role: {
-            id: "Admin",
-            name: "Admin",
-          },
-          timeZone: "Europe/Kirov",
-          locale: "en_US",
-          userAddress: {
-            country: "",
-            state: "",
-            city: "",
-            line: "",
-            zipCode: "",
-          },
-          createdAt: "2017-05-12T08:34:30.283Z",
-        },
-        {
-          blocked: false,
-          verified: false,
-          id: "e07c63f0-dd8c-4ad4-983e-4ee7dc600463",
-          username: "jane.doe@opsgenie.com",
-          fullName: "jane doe",
-          role: {
-            id: "Admin",
-            name: "Admin",
-          },
-          timeZone: "Europe/Moscow",
-          locale: "en_GB",
-          tags: ["tag1", "tag3"],
-          userAddress: {
-            country: "US",
-            state: "Indiana",
-            city: "Terre Haute",
-            line: "567 Stratford Park",
-            zipCode: "47802",
-          },
-          details: {
-            detail1key: ["detail1dvalue1", "detail1value2"],
-            detail2key: ["detail2value"],
-          },
-          createdAt: "2017-05-12T09:39:14.41Z",
-        },
-      ],
-      paging: {
-        prev: "http://api.opsgenie.com/v2/users?limit=2&offset=1&order=DESC&sort=fullName&query=role%3Aadmin",
-        next: "http://api.opsgenie.com/v2/users?limit=2&offset=5&order=DESC&sort=fullName&query=role%3Aadmin",
-        first: "http://api.opsgenie.com/v2/users?limit=2&offset=0&order=DESC&sort=fullName&query=role%3Aadmin",
-        last: "http://api.opsgenie.com/v2/users?limit=2&offset=6&order=DESC&sort=fullName&query=role%3Aadmin",
-      },
-      took: 0.261,
-      requestId: "d2c50d0c-1c44-4fa5-99d4-20d1e7ca9938",
-    }
-  end
-
   describe "#all" do
     let(:users) { described_class.all }
 
     it "returns all users" do
+      stub = stub_user_list_request
+
       expect(users.count).to eq(2)
       expect(users.first).to be_a(Opsgenie::User)
       expect(users.first.id).to eq("b5b92115-bfe7-43eb-8c2a-e467f2e5ddc4")
@@ -87,6 +18,8 @@ RSpec.describe Opsgenie::User do
   end
 
   describe "#find_by_username" do
+    before { stub_user_list_request }
+
     let(:user) { described_class.find_by_username(username) }
 
     context "when user exists" do
@@ -108,6 +41,8 @@ RSpec.describe Opsgenie::User do
   end
 
   describe "#find_by_id" do
+    before { stub_user_list_request }
+
     let(:user) { described_class.find(id) }
 
     context "when user exists" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,9 +7,11 @@ require "dotenv"
 Dotenv.load
 
 require "webmock/rspec"
+require "support/webmock_helpers"
 
 RSpec.configure do |config|
   config.order = :random
+  config.include WebMockHelpers
 
   config.expect_with :rspec do |expectations|
     expectations.include_chain_clauses_in_custom_matcher_descriptions = true

--- a/spec/support/webmock_helpers.rb
+++ b/spec/support/webmock_helpers.rb
@@ -1,0 +1,20 @@
+module WebMockHelpers
+  def stub_get_request(url, body)
+    stub_request(:get, url)
+      .to_return(
+        body: body.to_json,
+        headers: {"Content-Type" => "application/json"}
+      )
+  end
+
+  def stub_user_list_request
+    body = JSON.parse File.read(File.join("spec", "fixtures", "users.json"))
+    url = "https://api.opsgenie.com/v2/users?limit=500"
+    stub_get_request(url, body)
+  end
+
+  def stub_schedule_show_request(url = "https://api.opsgenie.com/v2/schedules/b8e97704-0e9d-41b5-b27c-9d9027c83943?identifierType=id")
+    body = JSON.parse File.read(File.join("spec", "fixtures", "schedule.json"))
+    stub_get_request(url, body)
+  end
+end


### PR DESCRIPTION
This leverages the API to fetch full user details, so when we ask who is on call for a particular date, or a timeline, we get the full range of details about a user, and not just their email address. There's also a whole bunch of additions to make the timeline easier to work with, so it returns `TimelineRotation`s, which in turn have `TimelinePeriod`s.

I've also tidied up the mocking in tests too, so we can stub API calls with some simple helper methods.